### PR TITLE
Add Tap, TapAsync, TapError, TapErrorAsync

### DIFF
--- a/FunqTypes/Result.cs
+++ b/FunqTypes/Result.cs
@@ -147,6 +147,34 @@ public readonly record struct Result<T, E>(T Value, bool IsSuccess, List<E> Erro
             ? Fail(error)
             : this;
     }
+
+    /// <summary>
+    /// Executes an action on the successful value and returns the original result.
+    /// Useful for logging, debugging, or running side effects without modifying the result.
+    /// </summary>
+    /// <param name="action">Action on success value</param>
+    /// <returns>The same instance of <see cref="Result{T, E}"/></returns>
+    public Result<T, E> Tap(Action<T> action)
+    {
+        if(IsSuccess)
+            action(Value);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Executes an action on the error if the result is a failure.
+    /// Useful for logging, debugging, or running side effects without modifying the result.
+    /// </summary>
+    /// <param name="action">Action on the list of errors</param>
+    /// <returns>The same instance of <see cref="Result{T, E}"/></returns>
+    public Result<T, E> TapError(Action<List<E>> action)
+    {
+        if (!IsSuccess)
+            action(Errors);
+
+        return this;
+    }
     
     /// <summary>
     /// Implicitly converts a value into a successful result.

--- a/FunqTypes/ResultAsyncExtensions.cs
+++ b/FunqTypes/ResultAsyncExtensions.cs
@@ -1,0 +1,40 @@
+﻿namespace FunqTypes;
+
+public static class ResultAsyncExtensions
+{
+    /// <summary>
+    /// Executes an asynchronous action on the successful value and returns the original result.
+    /// Useful for async logging, debugging, or side effects without modifying the result. 
+    /// </summary>
+    /// <param name="resultTask">Async result</param>
+    /// <param name="action">Async action on success value</param>
+    /// <typeparam name="T">The value of the successful operation.</typeparam>
+    /// <typeparam name="E">One or more error explaining the failure.</typeparam>
+    /// <returns>Original result</returns>
+    public static async Task<Result<T, E>> TapAsync<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task> action)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsSuccess)
+            await action(result.Value).ConfigureAwait(false);
+        
+        return result;
+    }
+    
+    /// <summary>
+    /// Executes an asynchronous action on the error if the result is a failure.
+    /// Useful for async logging, debugging, or side effects on failures without modifying the error.
+    /// </summary>
+    /// <param name="resultTask">Async result</param>
+    /// <param name="action">Async action on errors</param>
+    /// <typeparam name="T">The value of the successful operation.</typeparam>
+    /// <typeparam name="E">One or more error explaining the failure.</typeparam>
+    /// <returns>Original result</returns>
+    public static async Task<Result<T, E>> TapErrorAsync<T, E>(this Task<Result<T, E>> resultTask, Func<List<E>, Task> action)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        if (!result.IsSuccess)
+            await action(result.Errors).ConfigureAwait(false);
+        
+        return result;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -315,6 +315,17 @@ Console.WriteLine(failed.IsGucci); // False
 Console.WriteLine(failed.Errors.First()); // "Must be positive"
 ```
 
+### 🕵🏻‍♀️ Using Tap() for logging and debugging
+
+```csharp
+var result = GetUserById(1)
+    .Tap(user => Console.WriteLine($"User found: {user.Name}"))
+    .Bind(ValidateUser)
+    .Tap(_ => Console.WriteLine("User validation passed"))
+    .Bind(CreateAccount);
+
+```
+
 ### 🚀 Result<T, E> API Summary
 | Method                                                                   | Description                                               |
 |--------------------------------------------------------------------------|-----------------------------------------------------------|
@@ -333,6 +344,8 @@ Console.WriteLine(failed.Errors.First()); // "Must be positive"
 | `.Where(predicate)`                                                      | Filters without specifying an error (uses `default(E)`)   |
 | `.Select(predicate)`                                                     | Transforms `T → U` while keeping `Result<T, E>` structure |
 | `.SelectMany(binder)`                                                    | Chains multiple `Result<T, E>` computations               |
+| `.Tap(action)`, `.TapAsync(action)`                                      | Use for logging success                                   |
+| `.TapError(binder)`, `TapErrorAsync(action)`                              | Use for debugging and logging failure                    |
 
 ### When to Use Each?
 | Use Case                                                             | Best Method                    |


### PR DESCRIPTION
This PR adds following methods for `Result<T, E>` type: `Tap(), TapAsync(), TapError(), TapErrorAsync()`

This will improve logging and debugging experience when using Result type