### PR TITLE
Add BindAsync, MapAsync, MapErrorAsync extensions; Add MapError to Result type

### DIFF
--- a/FunqTypes.Tests/ResultAsyncExtensionsTests.cs
+++ b/FunqTypes.Tests/ResultAsyncExtensionsTests.cs
@@ -1,0 +1,152 @@
+﻿namespace FunqTypes.Tests;
+
+public class ResultAsyncExtensionsTests
+{
+    #region MapAsync() Tests
+
+    [Fact]
+    public async Task MapAsync_ShouldTransformValue_WhenSuccess()
+    {
+        var result = Task.FromResult(Result<int, string>.Ok(42));
+
+        var mappedResult = await result.MapAsync(async x =>
+        {
+            await Task.Delay(10);
+            return x * 2;
+        });
+
+        Assert.True(mappedResult.IsSuccess);
+        Assert.Equal(84, mappedResult.Value);
+    }
+
+    [Fact]
+    public async Task MapAsync_ShouldNotTransform_WhenFailure()
+    {
+        var result = Task.FromResult(Result<int, string>.Fail("Original Error"));
+
+        var mappedResult = await result.MapAsync(async x =>
+        {
+            await Task.Delay(10);
+            return x * 2;
+        });
+
+        Assert.False(mappedResult.IsSuccess);
+        Assert.Single(mappedResult.Errors);
+        Assert.Equal("Original Error", mappedResult.Errors.First());
+    }
+
+    #endregion
+
+    #region MapErrorAsync() Tests
+
+    [Fact]
+    public async Task MapErrorAsync_ShouldTransformError_WhenFailure()
+    {
+        var result = Task.FromResult(Result<int, string>.Fail("Critical Failure"));
+
+        var mappedResult = await result.MapErrorAsync(async error =>
+        {
+            await Task.Delay(10);
+            return new ErrorDetails(error, DateTime.UtcNow);
+        });
+
+        Assert.False(mappedResult.IsSuccess);
+        Assert.Single(mappedResult.Errors);
+        Assert.Contains("Critical Failure", mappedResult.Errors.First().Message);
+    }
+
+    [Fact]
+    public async Task MapErrorAsync_ShouldNotTransform_WhenSuccess()
+    {
+        var result = Task.FromResult(Result<int, string>.Ok(42));
+
+        var mappedResult = await result.MapErrorAsync(async error =>
+        {
+            await Task.Delay(10);
+            return new ErrorDetails(error, DateTime.UtcNow);
+        });
+
+        Assert.True(mappedResult.IsSuccess);
+        Assert.Equal(42, mappedResult.Value);
+        Assert.Empty(mappedResult.Errors);
+    }
+
+    #endregion
+
+    #region BindAsync() Tests
+
+    [Fact]
+    public async Task BindAsync_ShouldFlattenAndChainResults_WhenSuccess()
+    {
+        var result = Task.FromResult(Result<int, string>.Ok(5));
+
+        async Task<Result<string, string>> AppendText(int value)
+        {
+            await Task.Delay(10);
+            return Result<string, string>.Ok($"Processed-{value}");
+        }
+
+        var chainedResult = await result.BindAsync(AppendText);
+
+        Assert.True(chainedResult.IsSuccess);
+        Assert.Equal("Processed-5", chainedResult.Value);
+    }
+
+    [Fact]
+    public async Task BindAsync_ShouldPropagateFailure_WithoutCallingBinder()
+    {
+        var result = Task.FromResult(Result<int, string>.Fail("Failed Input"));
+
+        async Task<Result<string, string>> AppendText(int value)
+        {
+            await Task.Delay(10);
+            return Result<string, string>.Fail($"Processed-{value}");
+        }
+
+        var chainedResult = await result.BindAsync(AppendText);
+
+        Assert.False(chainedResult.IsSuccess);
+        Assert.Single(chainedResult.Errors);
+        Assert.Equal("Failed Input", chainedResult.Errors.First());
+    }
+
+    #endregion
+
+    #region TapAsync() Tests
+
+    [Fact]
+    public async Task TapAsync_ShouldExecuteAction_WhenResultIsSuccess()
+    {
+        var result = Task.FromResult(Result<int, string>.Ok(42));
+        int capturedValue = 0;
+
+        var finalResult = await result.TapAsync(async value =>
+        {
+            await Task.Delay(10);
+            capturedValue = value;
+        });
+
+        Assert.True(finalResult.IsGucci);
+        Assert.Equal(42, finalResult.Value);
+        Assert.Equal(42, capturedValue);
+    }
+
+    [Fact]
+    public async Task TapAsync_ShouldNotExecuteAction_WhenResultIsFailure()
+    {
+        var result = Task.FromResult(Result<int, string>.Fail("Error"));
+        int capturedValue = 0;
+
+        var finalResult = await result.TapAsync(async value =>
+        {
+            await Task.Delay(10);
+            capturedValue = value;
+        });
+
+        Assert.False(finalResult.IsGucci);
+        Assert.NotEmpty(finalResult.Errors);
+        Assert.Equal(0, capturedValue);
+    }
+
+    #endregion
+}

--- a/FunqTypes/Result.cs
+++ b/FunqTypes/Result.cs
@@ -73,6 +73,17 @@ public readonly record struct Result<T, E>(T Value, bool IsSuccess, List<E> Erro
         IsSuccess ?
             Result<U, E>.Ok(func(Value))
             : Result<U, E>.Fail(Errors.ToArray());
+    
+    /// <summary>
+    /// Transforms the value of a failed result using provided function
+    /// </summary>
+    /// <param name="func"></param>
+    /// <typeparam name="F">The type of the transformed value.</typeparam>
+    /// <returns>A new <see cref="Result{T, F}"/> instance with the transformed errors or the existing value.</returns>
+    public Result<T, F> MapError<F>(Func<E, F> func) =>
+        IsSuccess
+            ? Result<T, F>.Ok(Value)
+            : Result<T, F>.Fail(Errors.Select(func).ToArray());
 
     /// <summary>
     /// Asynchronously transforms the value of a successful result using the provided function.

--- a/FunqTypes/ResultAsyncExtensions.cs
+++ b/FunqTypes/ResultAsyncExtensions.cs
@@ -3,6 +3,63 @@
 public static class ResultAsyncExtensions
 {
     /// <summary>
+    /// Asynchronously transforms the value of a successful async result using the provided function.
+    /// </summary>
+    /// <param name="resultTask">Async result</param>
+    /// <param name="mapper">An asynchronous function to transform the success value.</param>
+    /// <typeparam name="T">The current value type.</typeparam>
+    /// <typeparam name="U">The new value type after transformation.</typeparam>
+    /// <typeparam name="E">The error type.</typeparam>
+    /// <returns>A new <see cref="Result{U, E}"/> with transformed value if success, or the original error.</returns>
+    public static async Task<Result<U, E>> MapAsync<T, U, E>(
+        this Task<Result<T, E>> resultTask,
+        Func<T, Task<U>> mapper)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return result.IsSuccess
+            ? Result<U, E>.Ok(await mapper(result.Value).ConfigureAwait(false))
+            : Result<U, E>.Fail(result.Errors.ToArray());
+    }
+    
+    /// <summary>
+    /// Asynchronously transforms the error type of a failed <see cref="Result{T, E}"/>.
+    /// Leaves the success value unchanged.
+    /// </summary>
+    /// <typeparam name="T">The success type.</typeparam>
+    /// <typeparam name="E">The current error type.</typeparam>
+    /// <typeparam name="F">The new error type after transformation.</typeparam>
+    /// <param name="resultTask">The asynchronous result to transform.</param>
+    /// <param name="errorMapper">The asynchronous function to map existing errors to a new type.</param>
+    /// <returns>A new <see cref="Result{T, F}"/> with transformed errors if failure, or the original success.</returns>
+    public static async Task<Result<T, F>> MapErrorAsync<T, E, F>(
+        this Task<Result<T, E>> resultTask, Func<E, Task<F>> errorMapper)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return result.IsSuccess
+            ? Result<T, F>.Ok(result.Value)
+            : Result<T, F>.Fail(await Task.WhenAll(result.Errors.Select(errorMapper)).ConfigureAwait(false));
+    }
+    
+    /// <summary>
+    /// Asynchronously chains another async result-producing function.
+    /// </summary>
+    /// <param name="resultTask">Async result</param>
+    /// <param name="binder">An asynchronous function that takes the success value and returns a new <see cref="Result{U, E}"/>.</param>
+    /// <typeparam name="T">The type of the current result.</typeparam>
+    /// <typeparam name="U">The type of the new result.</typeparam>
+    /// <typeparam name="E">The type of the error.</typeparam>
+    /// <returns>A task representing a new <see cref="Result{U, E}"/> instance.</returns>
+    public static async Task<Result<U, E>> BindAsync<T, U, E>(
+        this Task<Result<T, E>> resultTask,
+        Func<T, Task<Result<U, E>>> binder)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return result.IsSuccess
+            ? await binder(result.Value).ConfigureAwait(false)
+            : Result<U, E>.Fail(result.Errors.ToArray());
+    }
+    
+    /// <summary>
     /// Executes an asynchronous action on the successful value and returns the original result.
     /// Useful for async logging, debugging, or side effects without modifying the result. 
     /// </summary>


### PR DESCRIPTION
Adds `BindAsync()`, `MapAsync()`, `MapErrorAsync()` extensions; 
Adds `MapError()` to `Result<T,E>`